### PR TITLE
Enabled dark and light mode with switch for docs using docsify-darklight-theme

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -8,7 +8,12 @@
   <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0">
   <link href="https://fonts.googleapis.com/css?family=Ubuntu:400,500,700" rel="stylesheet">
   <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.css" rel="stylesheet">
-  <link rel="stylesheet" href="//unpkg.com/docsify/lib/themes/vue.css">
+  <link 
+    rel="stylesheet"
+    href="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/style.min.css"
+    title="docsify-darklight-theme"
+    type="text/css"
+  />
 </head>
 <body>
   <div id="app"></div>
@@ -24,6 +29,10 @@
         noData: 'No Results.',
       }
     }
+  </script>
+  <script 
+    src="//cdn.jsdelivr.net/npm/docsify-darklight-theme@latest/dist/index.min.js"
+    type="text/javascript">
   </script>
   <script src="assets/js/app.js"></script>
   <script src="//unpkg.com/docsify/lib/docsify.min.js"></script>


### PR DESCRIPTION
Enabled dark and light mode with switch for docs using docsify-darklight-theme with redesigned search bar. For more customization [see here](https://boopathikumar018.github.io/docsify-darklight-theme)

**Light Mode :**

Before 

![image](https://user-images.githubusercontent.com/10001746/79602850-e2063300-8108-11ea-8b49-e74148ca258d.png)

After

![image](https://user-images.githubusercontent.com/10001746/79602484-2b09b780-8108-11ea-9274-998d93856304.png)

**Dark Mode :**

![image](https://user-images.githubusercontent.com/10001746/79602553-4f659400-8108-11ea-9241-34445117c774.png)

